### PR TITLE
Update avatar-params.html

### DIFF
--- a/layouts/partials/gravatar/avatar-params.html
+++ b/layouts/partials/gravatar/avatar-params.html
@@ -6,4 +6,5 @@
   {{ with default "Avatar" .Alt }}alt="{{ . }}"{{ end }}
   loading="lazy"
   src="{{ $url }}"
+  crossorigin="anonymous"
 />


### PR DESCRIPTION
While working to resolve Content-Security-Policy on my site I kept running into Cross-Origin-Resource-Policy and Cross-Origin-Embedder-Policy errors when using Gravatar for avatar images. Adding `crossorigin` or more specifically `crossorigin="anonymous"` to the `<img>` tag resolved these issues for me.

This has been tested on my site by placing this partial to override the module's copy and confirming the HTML generated includes the `crossorigin` attribute.